### PR TITLE
petsとstoresのPOST実行時のエラー処理の修正

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -69,6 +69,14 @@ paths:
                 example: 
                   code: 400
                   message: Bad Request
+        '404':
+          description: 存在しないSQSエンドポイントの指定
+          content:
+            application/json:
+              schema:
+                example: 
+                  code: 404
+                  message: Not Found
 
   /stores/{store_id}:
     get:
@@ -223,6 +231,14 @@ paths:
                 example: 
                   code: 400
                   message: Bad Request
+        '404':
+          description: 存在しないSQSエンドポイントの指定
+          content:
+            application/json:
+              schema:
+                example: 
+                  code: 404
+                  message: Not Found
 
   /pets/{pet_id}:
     get:

--- a/controller/pet_controller.go
+++ b/controller/pet_controller.go
@@ -4,6 +4,7 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/nfv-aws/wcafe-api-controller/service"
 	"log"
+	"strings"
 )
 
 // Controller is pet controlller
@@ -28,8 +29,13 @@ func (pc PetController) Create(c *gin.Context) {
 	p, err := pc.Service.Create(c)
 
 	if err != nil {
-		c.AbortWithStatus(400)
-		log.Println(err)
+		if strings.Contains(err.Error(), "InvalidAddress") {
+			c.AbortWithStatus(404)
+			log.Println(err)
+		} else {
+			c.AbortWithStatus(400)
+			log.Println(err)
+		}
 	} else {
 		c.JSON(201, p)
 	}

--- a/controller/store_controller.go
+++ b/controller/store_controller.go
@@ -5,6 +5,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/nfv-aws/wcafe-api-controller/service"
 	"log"
+	"strings"
 )
 
 // Controller is store controlller
@@ -29,8 +30,13 @@ func (sc StoreController) Create(c *gin.Context) {
 	p, err := sc.Storeservice.Create(c)
 
 	if err != nil {
-		c.AbortWithStatus(400)
-		log.Println(err)
+		if strings.Contains(err.Error(), "InvalidAddress") {
+			c.AbortWithStatus(404)
+			log.Println(err)
+		} else {
+			c.AbortWithStatus(400)
+			log.Println(err)
+		}
 	} else {
 		c.JSON(201, p)
 	}

--- a/controller/store_controller_test.go
+++ b/controller/store_controller_test.go
@@ -88,7 +88,35 @@ func TestStoreCreateOK(t *testing.T) {
 	assert.Equal(t, 201, c.Writer.Status())
 }
 
+func TestStoreCreateInvalidAddress(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	serviceMock := mocks.NewMockStoreService(ctrl)
+	serviceMock.EXPECT().Create(c).Return(entity.Store{}, ErrInvalidAddress)
+	controller := StoreController{Storeservice: serviceMock}
+
+	controller.Create(c)
+	assert.Equal(t, 404, c.Writer.Status())
+}
+
 func TestStoreCreateBadRequest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	serviceMock := mocks.NewMockStoreService(ctrl)
+	serviceMock.EXPECT().Create(c).Return(entity.Store{}, ErrBadRequest)
+	controller := StoreController{Storeservice: serviceMock}
+
+	controller.Create(c)
+	assert.Equal(t, 400, c.Writer.Status())
+}
+
+func TestStoreUpdate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 


### PR DESCRIPTION
### やったこと(追加機能/直したバグ)
- petsとstoresのPOST実行時にSQS接続不可の場合でもDBに登録されてしまうバグの対応
　- DB登録→SQSへSendMessageの順番を、SQSへSendMessage→DB登録へ変更
- pets_controllerとstores_controllerのテストの追加
- openapi.yamlに↑用のエラーコード404を追記
