### PR TITLE
add get pets id in openapi.yaml

### DIFF
--- a/api/openapi.yaml
+++ b/api/openapi.yaml
@@ -245,6 +245,14 @@ paths:
             application/json:
               schema: 
                 $ref: '#/components/schemas/pets'
+        '404':
+          description: 無効なパスの指定
+          content:
+            application/json:
+              schema:
+                example: 
+                  code: 404
+                  message: Not Found
 
     patch:
       summary: ID指定による商品の更新

--- a/controller/pet_controller_test.go
+++ b/controller/pet_controller_test.go
@@ -38,6 +38,21 @@ func TestPetGet(t *testing.T) {
 	assert.Equal(t, 200, c.Writer.Status())
 }
 
+func TestPetGetNotFound(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	c, _ := gin.CreateTestContext(httptest.NewRecorder())
+
+	serviceMock := mocks.NewMockPetService(ctrl)
+
+	serviceMock.EXPECT().Get(gomock.Any()).Return(service.Pet{}, ErrRecordNotFound)
+	controller := PetController{Service: serviceMock}
+
+	controller.Get(c)
+	assert.Equal(t, 404, c.Writer.Status())
+}
+
 func TestPetCreate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
### やったこと(追加機能/直したバグ)
- get pets/{pet_id}の設計を追加（openapi.yaml）
- 404は元々実装済み。
- get pets/{pet_id}のエラーのテストを追加
